### PR TITLE
Add CI build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           echo "${{ github.workspace }}/CEdev/bin" >> "$GITHUB_PATH"
 
       - name: Build
-        run: make -j4
+        run: make SHELL=/bin/bash -j4
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow that compiles the project using the CEdev v14.2 Linux toolchain
- Upload the resulting `OWLEYES.8xp` as a downloadable build artifact
- Runs on pushes to `main` and on pull requests targeting `main`

Closes #9

## Test plan

- [ ] GitHub Actions run completes successfully
- [ ] `OWLEYES.8xp` artifact is downloadable from the completed run