### PR TITLE
All-integer render loop with LUTs and temporal dithering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# Owl Eyes
+
+## Project
+
+A Lorenz attractor renderer for the TI-84 CE Plus calculator (eZ80 processor).
+
+## Build
+
+```sh
+make clean && make
+```
+
+Requires the [CEdev](https://github.com/CE-Programming/toolchain) toolchain (`cedev-config` must be on `$PATH`). Produces `bin/OWLEYES.8xp`.
+
+## Architecture
+
+Single source file: `src/main.c`. Two phases:
+
+1. **Precomputation** (runs once at startup): Generates 5,000 Lorenz attractor points via Euler integration, encodes each as three Q4.4 fixed-point `int8_t` values packed into a single 24-bit `int`. Also builds sin/cos/perspective lookup tables using float math (one-time cost).
+
+2. **Render loop** (runs every frame): All-integer. Unpacks points, applies Y-axis rotation via trig LUTs, applies perspective projection via perspective LUT, maps to screen coordinates, and draws. Uses temporal dithering (even/odd point alternation) to halve per-frame work.
+
+## Conventions
+
+- **Target platform**: eZ80 -- `int` is 24-bit, no FPU. All hot-path math must be integer-only.
+- **Fixed-point formats**: Q4.4 for stored coordinates (8-bit), Q8.8 for LUT values (24-bit `int`).
+- **Compiler flags**: `-Wall -Wextra -O3` (set in `makefile`).
+- Local clang/LSP diagnostics will show errors for CEdev headers (`tice.h`, `graphx.h`, etc.) -- these are expected and not real build errors.

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,24 @@
 ### Owl Eyes
 
-Basic Lorenz system plotter that rotates around the y-axis. Uses 8-bit Q4.4 floats to pack a 3D point into the TI-84 CE Plus's native 24-bit integer type and reduce memory overhead. Uses the [CEdev](https://github.com/CE-Programming/toolchain) toolchain.
+A rotating 3D Lorenz attractor for the TI-84 CE Plus calculator.
+
+Renders 5,000 precomputed Lorenz attractor points with real-time Y-axis rotation and perspective projection. Optimized for the eZ80 processor (8-bit CPU, ~48 MHz, no FPU):
+
+- **Q4.4 fixed-point packing** -- Three 8-bit coordinates packed into a single native 24-bit `int`, halving memory usage vs. storing floats.
+- **All-integer render loop** -- No floating-point math in the hot path. Trig (sin/cos) and perspective are served from precomputed Q8.8 lookup tables; all intermediate values fit in 24-bit native `int`.
+- **Temporal point dithering** -- Even/odd points alternate across frames, halving per-frame work while LCD persistence makes the output appear continuous.
+- **Double buffering** -- Draws to a back buffer and swaps, eliminating flicker.
+
+Uses the [CEdev](https://github.com/CE-Programming/toolchain) toolchain.
+
+#### Building
+
+```sh
+make clean && make
+```
+
+Produces `bin/OWLEYES.8xp`. Transfer to a TI-84 CE Plus or run in [CEmu](https://ce-programming.github.io/CEmu/).
+
+#### Controls
+
+- **CLEAR** -- Exit the program.

--- a/src/main.c
+++ b/src/main.c
@@ -9,20 +9,14 @@
 #define DT 0.005f
 // Scale the attractor values into the Q4.4 range.
 #define STORE_SCALE 0.1f
-// Inverse of STORE_SCALE to recover original values.
-#define INV_STORE_SCALE (1.0f / STORE_SCALE)
 
-// Q4.4 fixed-point conversion functions.
-// Multiply by 16 to convert a float to Q4.4.
-#define FLOAT_TO_FIXED4_4(F) (int8_t)(F * 16.0f)
-int8_t float_to_fixed4_4(float f) {
-    return (int8_t)(f * 16.0f);
-}
+// Q4.4 fixed-point conversion: multiply by 16 to encode.
+#define FLOAT_TO_FIXED4_4(F) ((int8_t)((F) * 16.0f))
 
-// Divide by 16 to convert from Q4.4 back to float.
-inline float fixed4_4_to_float(int8_t f) {
-    return ((float)f) / 16.0f;
-}
+// Perspective distance in fixed-point units (= 100 / 0.625).
+#define D_FX 160
+// Display scale in Q8.8 (1.5 * 256 = 384). Controls on-screen size.
+#define DISPLAY_SCALE_Q8 384
 
 /*
    Pack three 8-bit fixed-point (Q4.4) values into a single 24-bit int.
@@ -46,100 +40,120 @@ inline void unpack3(int packed, int8_t* x, int8_t* y, int8_t* z) {
 // Global array to store the Lorenz attractor points as packed 24-bit ints.
 static int packedPoints[MAX_POINTS];
 
+// Lookup tables for trig (Q8.8) and perspective (Q8.8 with display scale folded in).
+static int sinLUT[256];
+static int cosLUT[256];
+static int perspLUT[256];
+
 int main(void) {
     int numPoints = 0;
-    
+
     // Lorenz attractor parameters.
     const float sigma = 10.0f;
     const float beta  = 8.0f / 3.0f;
     const float rho   = 28.0f;
-    
+
     // Initial conditions.
     float x = 0.1f, y = 0.0f, z = 0.0f;
-    
+
     // Precompute the Lorenz attractor points.
-    // We scale the values by STORE_SCALE before converting to Q4.4 fixed-point.
+    // We scale the values by STORE_SCALE and encode as Q4.4 fixed-point.
     for (int i = 0; i < MAX_POINTS; i++) {
         float dx = sigma * (y - x);
         float dy = x * (rho - z) - y;
         float dz = x * y - beta * z;
-        
+
         x += DT * dx;
         y += DT * dy;
         z += DT * dz;
-        
+
         // Scale and convert to Q4.4 fixed-point.
-        int8_t fx = (int8_t)(x * STORE_SCALE);
-        int8_t fy = (int8_t)(y * STORE_SCALE);
-        int8_t fz = (int8_t)(z * STORE_SCALE);
-        
+        int8_t fx = FLOAT_TO_FIXED4_4(x * STORE_SCALE);
+        int8_t fy = FLOAT_TO_FIXED4_4(y * STORE_SCALE);
+        int8_t fz = FLOAT_TO_FIXED4_4(z * STORE_SCALE);
+
         // Pack all three coordinates into one int.
         packedPoints[i] = pack3(fx, fy, fz);
         numPoints++;
     }
-    
-    // Initialize graphics for direct drawing.
+
+    // Build trig lookup tables (256 entries, Q8.8 format).
+    for (int i = 0; i < 256; i++) {
+        float rad = (float)i * (2.0f * 3.14159265f / 256.0f);
+        sinLUT[i] = (int)(sinf(rad) * 256.0f);
+        cosLUT[i] = (int)(cosf(rad) * 256.0f);
+    }
+
+    // Build perspective lookup table: maps zRot to (D_FX * DISPLAY_SCALE_Q8) / (D_FX + zRot).
+    // Index i corresponds to zRot = i - 128.
+    for (int i = 0; i < 256; i++) {
+        int denom = D_FX + (i - 128);
+        if (denom < 1) denom = 1;
+        perspLUT[i] = (D_FX * DISPLAY_SCALE_Q8) / denom;
+    }
+
+    // Initialize graphics with double buffering.
     gfx_Begin();
-    gfx_SetDrawScreen();
+    gfx_SetDrawBuffer();
     gfx_SetColor(255); // Set drawing color to white.
-    gfx_FillScreen(0); // Clear the screen (black background).
-    
-    // Screen mapping parameters.
+    gfx_FillScreen(0); // Clear the back buffer (black background).
+
+    // Screen center offsets.
     int xOffset = GFX_LCD_WIDTH / 2;
     int yOffset = GFX_LCD_HEIGHT / 2;
-    float scaleX = 4.0f;
-    float scaleY = 4.0f;
-    
-    // Rotation and perspective parameters.
-    float angle = 0.0f;      // Starting rotation angle.
-    float rotSpeed = 0.05f;  // Rotation speed (radians per frame).
-    float d = 100.0f;        // Perspective distance.
-    
-    // Animation loop: redraw all stored points with the current rotation.
+
+    // Rotation state: uint8_t index into 256-entry LUT.
+    // Step of 2 per frame ~ 0.049 rad/frame, matching original 0.05.
+    // Wraps naturally via uint8_t overflow.
+    uint8_t angle_idx = 0;
+    uint8_t angle_step = 2;
+
+    uint8_t frameCount = 0;
+
+    // Animation loop: redraw stored points with the current rotation.
     while (true) {
-        gfx_FillScreen(0);  // Clear the screen.
-        
-        const float cosTheta = cosf(angle);
-        const float sinTheta = sinf(angle);
-        
-        // Process each stored point.
-        for (int i = 0; i < numPoints; i++) {
+        gfx_FillScreen(0);  // Clear the back buffer.
+
+        int cosA = cosLUT[angle_idx];
+        int sinA = sinLUT[angle_idx];
+
+        // Temporal dithering: draw even-indexed points on even frames,
+        // odd-indexed on odd frames. Halves per-frame work; LCD persistence
+        // makes alternating frames appear continuous.
+        for (int i = (frameCount & 1); i < numPoints; i += 2) {
             int8_t fx, fy, fz;
             unpack3(packedPoints[i], &fx, &fy, &fz);
-            
-            // Convert fixed-point values back to float and recover original scale.
-            float orig_x = (((float)fx) / 16.0f) * INV_STORE_SCALE;
-            float orig_y = (((float)fy) / 16.0f) * INV_STORE_SCALE;
-            float orig_z = (((float)fz) / 16.0f) * INV_STORE_SCALE;
-            
-            // Rotate the point around the y-axis.
-            float xRot = orig_x * cosTheta + orig_z * sinTheta;
-            float zRot = -orig_x * sinTheta + orig_z * cosTheta;
-            float yVal = orig_y;  // y remains unchanged.
-            
-            // Apply a simple perspective projection.
-            float factor = d / (d + zRot);
-            
-            // Map the 3D point to 2D screen coordinates.
-            int screenX = xOffset + (int)(xRot * factor * scaleX);
-            int screenY = yOffset - (int)(yVal * factor * scaleY);
-            
-            // Draw the pixel if it's within screen bounds.
-            if (screenX >= 0 && screenX < GFX_LCD_WIDTH &&
-                screenY >= 0 && screenY < GFX_LCD_HEIGHT) {
+
+            // Y-axis rotation (all 24-bit integer math).
+            int xRot = (fx * cosA + fz * sinA) >> 8;
+            int zRot = (-fx * sinA + fz * cosA) >> 8;
+
+            // Perspective + display scale via LUT.
+            int zIdx = zRot < -128 ? -128 : (zRot > 127 ? 127 : zRot);
+            int factor = perspLUT[zIdx + 128];
+
+            // Map to screen coordinates.
+            int screenX = xOffset + ((xRot * factor) >> 8);
+            int screenY = yOffset - ((fy * factor) >> 8);
+
+            // Bounds check: unsigned cast makes negatives wrap to large values,
+            // collapsing 4 comparisons into 2.
+            if ((unsigned int)screenX < GFX_LCD_WIDTH &&
+                (unsigned int)screenY < GFX_LCD_HEIGHT) {
                 gfx_SetPixel(screenX, screenY);
             }
         }
-        
-        gfx_SwapDraw();  // Display the frame.
-        angle += rotSpeed;  // Update the rotation angle.
-        
+
+        gfx_SwapDraw();          // Present the frame.
+        angle_idx += angle_step; // Advance rotation (wraps naturally).
+        frameCount++;            // Advance frame counter (wraps naturally).
+
         kb_Scan();
         if (kb_Data[6] & kb_Clear) {  // Exit on [CLEAR].
             break;
         }
     }
-    
+
     gfx_End();
     return 0;
 }


### PR DESCRIPTION
## Summary

- Fix Q4.4 encoding bug: use `FLOAT_TO_FIXED4_4` macro instead of plain truncation, recovering ~4 bits of precision
- Fix double-buffer setup: `gfx_SetDrawBuffer()` instead of `gfx_SetDrawScreen()` to eliminate flicker
- Replace all float math in the render loop with 24-bit integer operations
- Add 256-entry sin/cos (Q8.8) and perspective lookup tables, built once at startup
- Add temporal point dithering: even/odd frames render alternating point subsets, halving per-frame work
- Remove dead float code (`float_to_fixed4_4()`, `fixed4_4_to_float()`, `INV_STORE_SCALE`, float rotation/perspective variables)

Closes #7

## Test plan

- [ ] CI build passes (compiles clean under `-Wall -Wextra`)
- [ ] Transfer `OWLEYES.8xp` to TI-84 CE Plus or CEmu and verify:
  - Attractor shape is correct
  - Rotation is smooth
  - No flicker
  - CLEAR key exits cleanly
- [ ] Frame rate should be noticeably higher vs. the float-based render loop