### PR TITLE
Update README and CLAUDE.md to reflect current architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,13 +16,15 @@ Requires the [CEdev](https://github.com/CE-Programming/toolchain) toolchain (`ce
 
 Single source file: `src/main.c`. Two phases:
 
-1. **Precomputation** (runs once at startup): Generates 5,000 Lorenz attractor points via Euler integration, encodes each as three Q4.4 fixed-point `int8_t` values packed into a single 24-bit `int`. Also builds sin/cos/perspective lookup tables using float math (one-time cost).
+1. **Precomputation** (runs once at startup): Generates 2,500 Lorenz attractor points via Euler integration with adaptive time stepping (smaller steps in fast-transit regions, larger in dense lobe centers). Encodes each as three Q4.4 fixed-point `int8_t` values packed into a single 24-bit `int`. Also builds sin/cos/perspective lookup tables and a Y-axis frustum culling threshold using float math (one-time cost).
 
-2. **Render loop** (runs every frame): All-integer. Unpacks points, applies Y-axis rotation via trig LUTs, applies perspective projection via perspective LUT, maps to screen coordinates, and draws. Uses temporal dithering (even/odd point alternation) to halve per-frame work.
+2. **Render loop** (runs every frame): All-integer. For each stored point, unpacks coordinates, applies early Y-axis culling, computes factored Y-axis rotation products, and renders both the original point and its `(-x, -y, z)` mirror (exploiting Lorenz Z2 symmetry). Uses perspective LUT, depth-based coloring (8-band white-to-blue gradient), temporal dithering (even/odd point alternation), and 4x manual loop unrolling. The `PROCESS_POINT` macro encapsulates the per-point body.
 
 ## Conventions
 
 - **Target platform**: eZ80 -- `int` is 24-bit, no FPU. All hot-path math must be integer-only.
 - **Fixed-point formats**: Q4.4 for stored coordinates (8-bit), Q8.8 for LUT values (24-bit `int`).
+- **STORE_SCALE**: `0.15` -- maps Lorenz values into Q4.4 range. `D_FX` and `DISPLAY_SCALE_Q8` must be adjusted together with this value to keep on-screen size consistent.
 - **Compiler flags**: `-Wall -Wextra -O3` (set in `makefile`).
+- **CI**: `.github/workflows/build.yml` -- builds with CEdev v14.2 on Ubuntu, uploads `.8xp` artifact. The makefile sets `SHELL=/bin/zsh`; CI overrides with `SHELL=/bin/bash`.
 - Local clang/LSP diagnostics will show errors for CEdev headers (`tice.h`, `graphx.h`, etc.) -- these are expected and not real build errors.

--- a/readme.md
+++ b/readme.md
@@ -2,11 +2,16 @@
 
 A rotating 3D Lorenz attractor for the TI-84 CE Plus calculator.
 
-Renders 5,000 precomputed Lorenz attractor points with real-time Y-axis rotation and perspective projection. Optimized for the eZ80 processor (8-bit CPU, ~48 MHz, no FPU):
+Renders 2,500 precomputed Lorenz attractor points (plus their Z2-symmetric mirrors) with real-time Y-axis rotation, perspective projection, and depth coloring. Optimized for the eZ80 processor (8-bit CPU, ~48 MHz, no FPU):
 
 - **Q4.4 fixed-point packing** -- Three 8-bit coordinates packed into a single native 24-bit `int`, halving memory usage vs. storing floats.
 - **All-integer render loop** -- No floating-point math in the hot path. Trig (sin/cos) and perspective are served from precomputed Q8.8 lookup tables; all intermediate values fit in 24-bit native `int`.
+- **Z2 symmetry exploitation** -- Stores half the trajectory and renders both each point and its `(-x, -y, z)` mirror, halving memory usage while maintaining full visual coverage.
+- **Adaptive precomputation** -- Variable time step during Euler integration distributes points evenly across the attractor's surface (more points on fast-transit arcs, fewer on dense lobe centers).
+- **Depth coloring** -- 8-band white-to-blue gradient mapped from post-rotation z-depth. Near points render bright, far points dim.
 - **Temporal point dithering** -- Even/odd points alternate across frames, halving per-frame work while LCD persistence makes the output appear continuous.
+- **Early frustum culling** -- Y-axis pre-check skips off-screen points before rotation math.
+- **4x loop unrolling** -- Render loop manually unrolled to reduce branch overhead on the branchless eZ80 pipeline.
 - **Double buffering** -- Draws to a back buffer and swaps, eliminating flicker.
 
 Uses the [CEdev](https://github.com/CE-Programming/toolchain) toolchain.


### PR DESCRIPTION
## Summary

- Update point count from 5,000 to 2,500 (with Z2 mirrors)
- Document all optimizations: adaptive time stepping, Z2 symmetry, depth coloring, early frustum culling, 4x loop unrolling, PROCESS_POINT macro
- Add CI and STORE_SCALE conventions to CLAUDE.md

## Test plan

- [ ] CI build passes (docs-only change)